### PR TITLE
Center images in results card

### DIFF
--- a/leaderboard/templates/leaderboard/components/results_card.html
+++ b/leaderboard/templates/leaderboard/components/results_card.html
@@ -10,7 +10,7 @@
     <div class="result-card result-img w3-row">
       <div class="w3-col spacer m1">&nbsp</div>
       <div class="w3-col w3-padding-large m10">
-        <img class="w3-image" src="{{ q.image.url }}" style="display:inline-flex;">
+        <img class="w3-image" src="{{ q.image.url }}" style="display:block;margin:auto;">
       </div>
       <div class="spacer w3-colm1">&nbsp</div>
     </div>


### PR DESCRIPTION
Small change to center the blue square on the results page.