### PR TITLE
Leaderboard pagination fix

### DIFF
--- a/leaderboard/htmx.py
+++ b/leaderboard/htmx.py
@@ -87,10 +87,17 @@ class LeaderboardHTMXView(SeriesPermissionMixin, View):
         except (TypeError, ValueError):
             page = 1
 
+        # leaderboard pagination logic
         lb_page_start = (page - 1) * 100
         lb_page_end = min(len(leaderboard), page * 100)
-        leaderboard = leaderboard[lb_page_start:lb_page_end]
+        prev_page = page - 1 or None
+        if lb_page_end >= len(leaderboard):
+            next_page = None
+        else:
+            next_page = page + 1
+
         visible_players = f"{lb_page_start + 1}-{lb_page_end}"
+        leaderboard = leaderboard[lb_page_start:lb_page_end]
         leaderboard = leaderboard.to_dict(orient='records')
 
         context = {
@@ -101,7 +108,9 @@ class LeaderboardHTMXView(SeriesPermissionMixin, View):
             'follow_filter': follow_filter,
             'visible_players': visible_players,
             'total_players': total_players,
-            'page': page
+            'page': page,
+            'next': next_page,
+            'prev': prev_page
         }
 
         return render(request, 'leaderboard/components/leaderboard.html', context)

--- a/leaderboard/templates/leaderboard/components/leaderboard.html
+++ b/leaderboard/templates/leaderboard/components/leaderboard.html
@@ -57,11 +57,13 @@
       </table>
       <div class="w3-container w3-cell-row w3-center w3-padding-16">
 
+        {% if prev %}
         <a class="w3-cell"
            hx-get="/leaderboard/htmx/?game_id={{ game_id }}&series={{ series_slug|default:"" }}&page={{ page|add:-1 }}"
            hx-target="#component-leaderboard">
           <i class="fas fa-chevron-left" style="color:#0095da"></i>
         </a>
+        {% endif %}
 
         <div class="w3-cell">
         {% if visible_players == 0 and not user.is_authenticated %}
@@ -76,11 +78,13 @@
         {% endif %}
         </div>
 
+        {% if next %}
         <a class="w3-cell"
            hx-get="/leaderboard/htmx/?game_id={{ game_id }}&series={{ series_slug|default:"" }}&page={{ page|add:1 }}"
            hx-target="#component-leaderboard">
           <i class="fas fa-chevron-right" style="color:#0095da"></i>
         </a>
+      {% endif %}
 
       </div>
     </div>


### PR DESCRIPTION
Resolves #310 

Remove arrows if there's no previous or next page.