### PR TITLE
Fix auto-update responses, new players filter

### DIFF
--- a/game/gsheets_api.py
+++ b/game/gsheets_api.py
@@ -182,7 +182,7 @@ def write_new_responses_to_gdrive(gid):
     redis_key = f'responses_{game.series.slug}_{game.game_id}'
     if REDIS.get(redis_key):
         return
-    REDIS.set(redis_key, 'true', ex=60)
+    REDIS.set(redis_key, 'true', timeout=60)
     sheet_doc = get_sheet_doc(game)
     responses = raw_answers_db_to_df(game)
     write_responses_sheet(sheet_doc, responses)

--- a/game/utils.py
+++ b/game/utils.py
@@ -17,7 +17,7 @@ def new_players_for_game(slug, game_id):
         ).order_by('player_id').filter(
             question__game__game_id__min=game_id, question__game__series__slug=slug
         ).values_list('player_id', flat=True)
-        REDIS.set(cache_key, str(list(new_players)), ex=60 * 60)
+        REDIS.set(cache_key, str(list(new_players)), timeout=60 * 60)
         return new_players
     return literal_eval(new_players_from_cache)
 


### PR DESCRIPTION
Resolves #467

Same bug, Django cache framework uses slightly different keyword arg `timeout` than Redis `ex`.