### PR TITLE
Check for reward

### DIFF
--- a/rewards/utils.py
+++ b/rewards/utils.py
@@ -1,6 +1,5 @@
 from django.template.loader import render_to_string
 from project import settings
-from rewards.models import Claim
 from mail.utils import send_one
 from project.utils import slackit
 
@@ -13,17 +12,12 @@ def check_for_reward(player):
     if player.game_ids.count() > 1:
         # This prevents a player with 10 referees who has not claimed
         # a reward yet from getting a multiple notices when referees
-        # play again.
+        # play again.  i.e. this a new player and a new referral.
         return
 
     referrer = player.referrer
 
     if referrer:
-        claim = Claim.objects.filter(player=referrer).first()
-        if claim:
-            # Don't send reward notice email if claim was already made.
-            return
-
         if settings.REWARD_THRESHOLD == referrer.players_referred.count():
             slackit(f"{referrer} earned a coffee mug.")
             try:


### PR DESCRIPTION
Changed logic in check_for_reward().  If a referrer had 10 referees and did not make a claim then every time those referees played a new game the referrer would get notified.  Now the code checks to make sure the referee is playing their first game, a new player.  Because of adding in this check we no longer need to check if the referrer made a claim.

In other words: players will only get notified about an earned reward when the 10th referee plays for the first time.