### PR TITLE
"Responsive" image swapping

### DIFF
--- a/leaderboard/static/leaderboard/css/base.css
+++ b/leaderboard/static/leaderboard/css/base.css
@@ -103,9 +103,6 @@ table.leaderboard td:first-child {
   #following-drp {
     padding: 8px 12px;
   }
-  .hide-mobile {
-    display: None;
-  }
 }
 
 /* FOLLOWING CHECKBOXES */

--- a/mail/templates/mail/mail_base.html
+++ b/mail/templates/mail/mail_base.html
@@ -48,7 +48,7 @@
                 <img id="email-header-image"
                      src="https://commonologygame.com/static/img/logo.png"
                      style="display: block;padding: 8px 24px;max-width: 320px;margin: auto"
-                     alt="header logo">
+                     alt="Commonology">
                 </a>
           </div>
 

--- a/project/static/css/base.css
+++ b/project/static/css/base.css
@@ -152,3 +152,17 @@ font-weight: normal;
 color:#9e9e9e;
 font-size: 12px;"
 }
+
+/* For swapping content on mobile */
+.mobile-only {
+  display: none
+}
+
+@media only screen and (max-width: 560px) {
+  .mobile-only {
+    display: block;
+  }
+  .desktop-only {
+    display: none;
+  }
+}


### PR DESCRIPTION
Resolves #689 

Swap images at 560px width. Use classes `mobile-only` and `desktop-only` to specify. Two images can be included in a component. Do not use the same component for email.