### PR TITLE
fix bug in how percentile is calculated

### DIFF
--- a/leaderboard/leaderboard.py
+++ b/leaderboard/leaderboard.py
@@ -201,13 +201,14 @@ def _answer_tally_from_cache(game):
 @quick_cache()
 def player_score_rank_percentile(player, game):
     answer_tally = build_answer_tally(game)
-    filtered_leaderboard = build_filtered_leaderboard(game, answer_tally, player_ids=[player.id])
+    game_leaderboard = build_filtered_leaderboard(game, answer_tally)
+    player_result = game_leaderboard[game_leaderboard['id'] == player.id]
     try:
-        score = filtered_leaderboard['Score'].values[0]
-        rank = filtered_leaderboard['Rank'].values[0]
+        score = player_result['Score'].values[0]
+        rank = player_result['Rank'].values[0]
     except IndexError:
         return None, None, None
-    percentile = rank / len(filtered_leaderboard)
+    percentile = rank / len(game_leaderboard)
     return score, rank, percentile
 
 


### PR DESCRIPTION
Resolve #723 

I was dividing by the length of the filtered leaderboard, which is always 1 because it was filtered to the player. 