### PR TITLE
Use redirect link to join page to auto-join users on login

### DIFF
--- a/users/templatetags/navbar_extras.py
+++ b/users/templatetags/navbar_extras.py
@@ -37,6 +37,7 @@ def login_next_url(request):
     if val := request.GET.get("next"):
         return f"?next={val}"
     p = request.path
-    if p == "/login/" or p == "/join/":
-        return ""
-    return f"?next={p}"
+    qp = request.GET.urlencode()
+    if p == "/login/":
+        p = "/join/"
+    return f"?next={p}?{qp}"

--- a/users/views.py
+++ b/users/views.py
@@ -169,12 +169,7 @@ class JoinView(CardFormView):
         elif request.user.is_authenticated:
             # If you're a known user, get added automatically
             request.user.series.add(series)
-            messages.info(request, f'You have been added to the game series "{series.name}"!')
-            self.custom_message = (
-                f'You have been added to the game series "{series.name}"! '
-                f"You will receive an email when the game begins. You can close this browser now."
-            )
-            return self.info(request, message=self.custom_message)
+            return redirect("series-leaderboard:series-home", series_slug)
 
         # If you're not a known user, show the join form
         self.custom_message = f'Join the game series "{series.name}" on Commonology.'
@@ -201,7 +196,7 @@ class JoinView(CardFormView):
                     f"Looks like you've played with us before! We sent a link to your email "
                     f'to join the game series "{series.name}"',
                 )
-                return redirect("login")
+                return redirect(reverse("login") + f"?c={series_slug}")
 
         except User.DoesNotExist:
             pass


### PR DESCRIPTION
So simple, so beautiful. Works for username/pw auth as well as google auth. Basically send people through the join flow when they login. If they're users they'll end up at the home page anyway.