### PR TITLE
Log requests and responses, and track requests

### DIFF
--- a/leaderboard/views.py
+++ b/leaderboard/views.py
@@ -1,5 +1,6 @@
 import datetime
 import dateutil
+import logging
 
 from django.shortcuts import render
 from django.http import Http404, HttpResponse
@@ -24,6 +25,8 @@ from leaderboard.leaderboard import (
 )
 from leaderboard.tasks import save_last_visit_t
 from leaderboard.models import PlayerRankScore
+
+logger = logging.getLogger(__name__)
 
 
 class LeaderboardView(BaseGameView):
@@ -124,6 +127,7 @@ class LeaderboardView(BaseGameView):
         if self.game is None:
             return render(request, "leaderboard/leaderboard_view.html", self._get_no_game_context())
 
+        logger.info(f"Loading leaderboard for series {self.slug} and game {self.game.game_id}")
         messages.info(request, "Login to follow your friends and join the conversation!")
         return render(request, "leaderboard/leaderboard_view.html", self.get_context(*args, **kwargs))
 

--- a/project/log_context.py
+++ b/project/log_context.py
@@ -1,0 +1,54 @@
+from typing import Generator
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+import logging
+
+
+class LogContext(logging.Filter):
+
+    context: ContextVar[dict] = ContextVar("context")
+
+    def filter(self, record) -> bool:
+        try:
+            for key, val in self.context.get().items():
+                if key not in record.__dict__:
+                    # Only set the value if it doesn't already exist. This prevents overwriting core
+                    # log record attributes such as 'message', 'levelname', etc, and allows
+                    # users to override the value set by the context logger in downstream code.
+                    setattr(record, key, val)
+            return True
+        except LookupError:
+            # No context set!
+            return True
+
+
+@contextmanager
+def log_context(**kwargs) -> Generator[None, None, None]:
+    """
+    A context manager which injects context-specific information into logs as "extra".
+
+    Example:
+        with log_context(foo="bar"):
+            logger.info("Hello, world!")
+
+        This will log "Hello, world!" with an extra field "foo" set to "bar".
+
+    These fields can be overridden on individual log messages within the context manager.
+
+    Example:
+        with log_context(foo="bar"):
+            logger.info("Hello, world!", extra={"foo": "baz"})
+
+        This will log "Hello, world!" with an extra field "foo" set to "baz".
+    """
+    # get the current context if available, default to a empty dict
+    current_context = LogContext.context.get({})
+    # sync upstream context with new context
+    merge_context = {**current_context, **kwargs}
+    try:
+        token = LogContext.context.set(merge_context)
+        yield
+    finally:
+        # reset the context variable to the with the merged values
+        LogContext.context.reset(token)

--- a/project/middleware.py
+++ b/project/middleware.py
@@ -1,3 +1,13 @@
+from django.middleware.common import CommonMiddleware
+from django.http import HttpRequest, HttpResponse
+import logging
+import uuid
+
+from project.log_context import log_context
+
+logger = logging.getLogger(__name__)
+
+
 class ParametersMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
@@ -7,3 +17,19 @@ class ParametersMiddleware:
             parameter = key.strip("?")
             request.session[parameter] = value
         return self.get_response(request)
+
+
+class RequestLoggingMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        request_id = str(uuid.uuid4())
+        request.META["REQUEST_ID"] = request_id
+        user_id = request.user.id
+
+        with log_context(request_id=request_id, user_id=user_id):
+            logger.info(f"Received request: {request.method} {request.path}")
+            response = self.get_response(request)
+            logger.info(f"Sending response: {request.method} {request.path} | " f"Status: {response.status_code}")
+            return response

--- a/project/settings.py
+++ b/project/settings.py
@@ -128,6 +128,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "request.middleware.RequestMiddleware",
     "project.middleware.ParametersMiddleware",
+    "project.middleware.RequestLoggingMiddleware",
 ]
 
 if DEBUG_TOOLBAR:
@@ -253,6 +254,11 @@ HANDLERS = ["console", "logtail"] if env.get("LOGTAIL_TOKEN") else ["console"]
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
+    "filters": {
+        "log_context": {
+            "()": "project.log_context.LogContext",
+        },
+    },
     "formatters": {
         "simple": {
             "format": "%(asctime)s - %(name)s - %(levelname)s - %(module)s:%(funcName)s:%(lineno)d - %(message)s",
@@ -263,19 +269,18 @@ LOGGING = {
         "console": {
             "class": "logging.StreamHandler",
             "formatter": "simple",
+            "filters": ["log_context"],
         },
         "logtail": {
             "class": "logtail.LogtailHandler",
             "source_token": env.get("LOGTAIL_TOKEN"),
+            "filters": ["log_context"],
         },
     },
     "loggers": {
         "django": {
             "level": "INFO",
             "propagate": True,
-        },
-        "django.request": {
-            "level": "INFO",
         },
         "": {
             "handlers": HANDLERS,


### PR DESCRIPTION
Adds some boilerplate request/response logs to get some visibility into site access patterns, and help with debugging. Also adds `request_id` and `user_id` to all request-generated log messages so we can more easily recreate user experiences when they have trouble.